### PR TITLE
Initially collapse task lists

### DIFF
--- a/src/components/containers/TaskList.js
+++ b/src/components/containers/TaskList.js
@@ -145,6 +145,17 @@ const TaskList = () => {
     setSelected([]);
   };
 
+  const scheduleButton = (
+    <FullButton
+      primary={unscheduled.length}
+      disabled={!unscheduled.length}
+      onClick={() => scheduleSelected()}
+    >
+      Schedule {selected.length ? selected.length : 'All'}{' '}
+      {selected.length === 1 ? 'Task' : 'Tasks'}
+    </FullButton>
+  );
+
   return (
     <div>
       <Navbar onAdd={() => setCreating(true)} />
@@ -159,7 +170,11 @@ const TaskList = () => {
       ) : (
         ''
       )}
-      <TaskSection title="Not yet scheduled" emptyPrompt="No created tasks">
+      <TaskSection
+        title="Not yet scheduled"
+        emptyPrompt="No created tasks"
+        actionButton={scheduleButton}
+      >
         {unscheduled.map((task) => (
           <Task
             key={task.id}
@@ -171,14 +186,6 @@ const TaskList = () => {
           />
         ))}
       </TaskSection>
-      <FullButton
-        primary={unscheduled.length}
-        disabled={!unscheduled.length}
-        onClick={() => scheduleSelected()}
-      >
-        Schedule {selected.length ? selected.length : 'All'}{' '}
-        {selected.length === 1 ? 'Task' : 'Tasks'}
-      </FullButton>
       <TaskSection title="Scheduled" emptyPrompt="No scheduled tasks">
         {scheduled.map((task) => (
           <Task

--- a/src/components/presentational/Dropdown.js
+++ b/src/components/presentational/Dropdown.js
@@ -13,7 +13,7 @@ const StyledTaskSection = styled.div`
     max-height: ${(props) => (props.closed ? 0 : '100vh')};
     overflow: ${(props) => (props.closed ? 'hidden' : 'auto')};
     opacity: ${(props) => (props.closed ? 0 : 1)};
-    transition: all 0.5s ease-in-out;
+    transition: all 0.4s ease-in-out, max-height 0.3s ease-in-out;
   }
 `;
 
@@ -21,9 +21,22 @@ export const TaskSection = ({
   title,
   emptyPrompt,
   children,
-  defaultClosed = false
+  actionButton = ''
 }) => {
+  const defaultClosed = !children.length;
   const [closed, setClosed] = useState(defaultClosed);
+
+  useEffect(() => {
+    setClosed(!children.length);
+  }, [children.length]);
+
+  const content = children.length ? (
+    <>
+      {children} {!actionButton.length ? actionButton : ''}
+    </>
+  ) : (
+    <FullButton info>{emptyPrompt}</FullButton>
+  );
 
   return (
     <StyledTaskSection closed={closed}>
@@ -31,22 +44,12 @@ export const TaskSection = ({
         <Text primary style={{ marginRight: 'auto' }}>
           {title}
         </Text>
-        {children.length ? (
-          <Icon
-            src={closed ? 'arrow-down.svg' : 'arrow-up.svg'}
-            onClick={() => setClosed(!closed)}
-          />
-        ) : (
-          ''
-        )}
+        <Icon
+          src={closed ? 'arrow-down.svg' : 'arrow-up.svg'}
+          onClick={() => setClosed(!closed)}
+        />
       </Row>
-      <div className="content">
-        {children.length ? (
-          children
-        ) : (
-          <FullButton info>{emptyPrompt}</FullButton>
-        )}
-      </div>
+      <div className="content">{content}</div>
     </StyledTaskSection>
   );
 };

--- a/src/components/presentational/styled/Icon.js
+++ b/src/components/presentational/styled/Icon.js
@@ -3,6 +3,7 @@ import styled from 'styled-components';
 const Icon = styled.img`
   width: 25px;
   padding: 8px;
+  transition: all 0.15s ease-in-out;
 
   &:hover {
     background-color: #ddd;


### PR DESCRIPTION
Functional changes: 
* Collapsing task list now also collapses associated button
* Lists now defaults to closed (*adjustable*)
* When new task is added, automatically expands (*adjustable*)

UI changes:
* Changed some transition timers

Preview:
![collapse_lists](https://user-images.githubusercontent.com/44995807/72756218-6a644e80-3b81-11ea-910f-116f5613ead0.gif)
